### PR TITLE
REL-4333 Apply patch from Oracle to fix a bug in test suite

### DIFF
--- a/lib/HTML/TableExtract.pm
+++ b/lib/HTML/TableExtract.pm
@@ -438,7 +438,6 @@ sub _reset_state {
   $self->{_counts}        = [];
   $self->{_in_a_table}    = 0;
   $self->{_parsing}       = 0;
-  $self->tree->delete_content() if TREE();
 }
 
 sub _emsg {


### PR DESCRIPTION
This patch is taken unchanged from perl-HTML-TableExtract SRPM.

Patch reverts the commit badb303cc65c8b912b10086493d74cf2dabf265c, apparently it fixes one of the tests, according to the original patch short description.
Summary text of the patch in Oracle's RPM:
> Revert "purge trees on re-parse when in tree mode"